### PR TITLE
Screenshot scaling fix.

### DIFF
--- a/gui/pngexport.c
+++ b/gui/pngexport.c
@@ -69,6 +69,7 @@ void export_png(LPCALC lpCalc, TCHAR *filename) {
 		Bitmap *newBitmap = new Bitmap(lcd->display_width * scale, lcd->height * scale);
 		Graphics graphics(newBitmap);
 		graphics.SetInterpolationMode(InterpolationModeNearestNeighbor);
+		graphics.SetPixelOffsetMode(PixelOffsetModeHalf);
 		graphics.DrawImage(image, 0, 0, lcd->width * scale, lcd->height * scale);
 		// delete so we close the output file
 		delete image;


### PR DESCRIPTION
Currently, the screenshot made has problems on corners, looks like it moved left 1px and up 1px after the scaling.
I made an extra call to Graphics to fix this.
Screenshots before/after:
![image](https://user-images.githubusercontent.com/10085275/109183022-94ce0580-779e-11eb-8f24-f0f982023b8c.png) ![image](https://user-images.githubusercontent.com/10085275/109183093-a6afa880-779e-11eb-8140-6dfd1bbc932c.png)

