### PR TITLE
"DuplicateName" does not work for rom 0.2026 and 0.2014. "Memory Backup" covers all known versions.

### DIFF
--- a/utilities/var.c
+++ b/utilities/var.c
@@ -9,7 +9,7 @@
 const char self_test[] = "Self Test?";
 const char catalog[] = "CATALOG";
 const char txt73[] = "GRAPH  EXPLORER  SOFTWARE";
-const char txt86[] = "Already Installed";
+const char txt86[] = "Memory Backup";
 
 
 #define tmpread( fp ) \
@@ -732,3 +732,4 @@ TIFILE_t* FreeTiFile(TIFILE_t * tifile) {
 	free(tifile);
 	return NULL;
 }
+


### PR DESCRIPTION
Some prototype TI-86 versions get misidentified as TI-83 ROMs, causing them to not work. 